### PR TITLE
Handle images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "pyyaml==6.0.2",
   "dacite==1.9.2",
   "pluggy==1.5.0",
+  "matplotlib==3.10.1",
 ]
 requires-python = ">= 3.8"
 

--- a/q8s/matplotlib/backend.py
+++ b/q8s/matplotlib/backend.py
@@ -1,0 +1,43 @@
+import base64
+import io
+import matplotlib.backend_bases
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+
+class Q8SLoggerBackend(FigureCanvasAgg):
+    """Custom Matplotlib backend that logs images as base64-encoded strings."""
+
+    def print_png(self, filename_or_obj, *args, **kwargs):
+        """Override the PNG printing to log Base64 instead of saving to a file."""
+        buf = io.BytesIO()
+        super().print_png(buf, *args, **kwargs)
+
+        # Convert to base64
+        buf.seek(0)
+        encoded_image = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+        # Log to console
+        print(f"data:image/png;base64,{encoded_image}\n")
+
+
+FigureCanvas = Q8SLoggerBackend
+# Register the backend
+
+
+# Fix: Override `show()` to manually trigger rendering
+def show():
+    """Manually process all figures and log their base64 images."""
+    import matplotlib._pylab_helpers
+
+    # Get all active figures
+    figures = matplotlib._pylab_helpers.Gcf.get_all_fig_managers()
+
+    for manager in figures:
+        figure = manager.canvas.figure
+        canvas = Q8SLoggerBackend(figure)
+        canvas.draw()  # Render the figure
+        canvas.print_png(None)  # Trigger our Base64 logging
+
+
+# Register the custom show function
+matplotlib.backend_bases.show = show

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from q8s.matplotlib.backend import Q8SLoggerBackend
+
+import matplotlib.pyplot as plt
+
+
+class TestQ8SLoggerBackend(unittest.TestCase):
+    @patch("builtins.print")
+    def test_print_png_logs_base64(self, mock_print):
+        # Create a simple plot
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+
+        # Create an instance of the custom backend
+        canvas = Q8SLoggerBackend(fig)
+
+        # Call the print_png method
+        canvas.print_png(None)
+
+        # Check that print was called with the expected base64 string
+        self.assertTrue(mock_print.called)
+        args, _ = mock_print.call_args
+        self.assertTrue(args[0].startswith("data:image/png;base64,"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added:
- Matplotlib backend that serialises png images to base64 encoded
- Handle the base64 encoded image in kernel and send it to the notebook